### PR TITLE
UserInfoViewModel를 UserDefault로 수정해요

### DIFF
--- a/Front/Daily/Daily.xcodeproj/project.pbxproj
+++ b/Front/Daily/Daily.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		F6699BA42BD4664F00B1FDA7 /* ViewPager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6699BA32BD4664F00B1FDA7 /* ViewPager.swift */; };
 		F672993129B7621E00E392BD /* MultiDatePickerOnCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = F672993029B7621E00E392BD /* MultiDatePickerOnCalendar.swift */; };
 		F679B9A52C4ACA960027608D /* NoticeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F679B9A42C4ACA960027608D /* NoticeSheet.swift */; };
+		F68B39E22CE72ED500C458B7 /* UserDefaultManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68B39E12CE72ED500C458B7 /* UserDefaultManager.swift */; };
 		F6A19FFF2C39FDE400989FBF /* ModifyRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A19FFE2C39FDE400989FBF /* ModifyRecordView.swift */; };
 		F6A1A0032C3A459800989FBF /* modifyRecordCountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A1A0022C3A459800989FBF /* modifyRecordCountModel.swift */; };
 		F6A1A0052C3A45AA00989FBF /* modifyRecordDateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6A1A0042C3A45AA00989FBF /* modifyRecordDateModel.swift */; };
@@ -227,6 +228,7 @@
 		F6699BA32BD4664F00B1FDA7 /* ViewPager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewPager.swift; sourceTree = "<group>"; };
 		F672993029B7621E00E392BD /* MultiDatePickerOnCalendar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiDatePickerOnCalendar.swift; sourceTree = "<group>"; };
 		F679B9A42C4ACA960027608D /* NoticeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeSheet.swift; sourceTree = "<group>"; };
+		F68B39E12CE72ED500C458B7 /* UserDefaultManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultManager.swift; sourceTree = "<group>"; };
 		F6A19FFE2C39FDE400989FBF /* ModifyRecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyRecordView.swift; sourceTree = "<group>"; };
 		F6A1A0022C3A459800989FBF /* modifyRecordCountModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = modifyRecordCountModel.swift; sourceTree = "<group>"; };
 		F6A1A0042C3A45AA00989FBF /* modifyRecordDateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = modifyRecordDateModel.swift; sourceTree = "<group>"; };
@@ -475,6 +477,7 @@
 		F6016DB92CC4DFBE00FB637F /* Entities */ = {
 			isa = PBXGroup;
 			children = (
+				F68B39E02CE72EC800C458B7 /* Manager */,
 				F65ACDE02CC91CE200C67DD1 /* Services */,
 				F6016DE32CC6115800FB637F /* Environment */,
 				F637807929109AF000356212 /* Model */,
@@ -656,6 +659,14 @@
 				F672993029B7621E00E392BD /* MultiDatePickerOnCalendar.swift */,
 			);
 			path = Popup;
+			sourceTree = "<group>";
+		};
+		F68B39E02CE72EC800C458B7 /* Manager */ = {
+			isa = PBXGroup;
+			children = (
+				F68B39E12CE72ED500C458B7 /* UserDefaultManager.swift */,
+			);
+			path = Manager;
 			sourceTree = "<group>";
 		};
 		F6BEC928290F5894005EAF28 = {
@@ -1056,6 +1067,7 @@
 				F6CE8A2D2CD0B1940050A25A /* DailyAppInfoView.swift in Sources */,
 				F6CC15A42BA1E69700689A02 /* getCalendarDayModel.swift in Sources */,
 				F6CE8A272CCF61C80050A25A /* DailyCycleTypePicker.swift in Sources */,
+				F68B39E22CE72ED500C458B7 /* UserDefaultManager.swift in Sources */,
 				F61ADFE82BBEB77000C35948 /* UserInfoViewModel.swift in Sources */,
 				F6C2F22229221C410006BFC7 /* RecordOnList.swift in Sources */,
 				F6DF64B82BAFDCB800A17B9E /* SymbolOnMonth.swift in Sources */,

--- a/Front/Daily/Domain/Entities/Manager/UserDefaultManager.swift
+++ b/Front/Daily/Domain/Entities/Manager/UserDefaultManager.swift
@@ -1,0 +1,57 @@
+//
+//  UserDefaultManager.swift
+//  Daily
+//
+//  Created by seungyooooong on 11/15/24.
+//
+
+import Foundation
+
+class UserDefaultManager {
+    @UserDefault(key: .userID, defaultValue: nil) static var userID: Int?
+    @UserDefault(key: .startDay, defaultValue: nil) static var startDay: Int?
+    @UserDefault(key: .language, defaultValue: nil) static var language: String?
+    @UserDefault(key: .dateType, defaultValue: nil) static var dateType: String?
+    @UserDefault(key: .calendarState, defaultValue: nil) static var calendarState: String?
+    @UserDefault(key: .lastTime, defaultValue: nil) static var lastTime: String?
+    
+    static func setUserInfo(userInfo: UserInfoModel) {
+        userID = userInfo.uid
+        startDay = userInfo.set_startday
+        language = userInfo.set_language
+        dateType = userInfo.set_dateorrepeat
+        calendarState = userInfo.set_calendarstate
+        lastTime = userInfo.last_time
+    }
+}
+
+enum UserDefaultKey: String {
+    case userID
+    case startDay
+    case language
+    case dateType
+    case calendarState
+    case lastTime
+}
+
+@propertyWrapper
+struct UserDefault<T: Codable> {
+    let key: UserDefaultKey
+    let defaultValue: T?
+    let storage: UserDefaults = UserDefaults.standard
+    
+    init(key: UserDefaultKey,
+         defaultValue: T? = nil) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+    
+    var wrappedValue: T? {
+        get {
+            return self.storage.object(forKey: self.key.rawValue) as? T ?? self.defaultValue
+        }
+        set {
+            self.storage.set(newValue, forKey: self.key.rawValue)
+        }
+    }
+}

--- a/Front/Daily/Presentation/Splash/SplashViewModel.swift
+++ b/Front/Daily/Presentation/Splash/SplashViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 class SplashViewModel: ObservableObject {
     private let appLaunchUseCase: AppLaunchUseCase
@@ -24,6 +25,14 @@ class SplashViewModel: ObservableObject {
         self.isAppLaunching = true
         Timer.scheduledTimer(withTimeInterval: 2.1, repeats: false) { timer in
             self.isAppLoading = false
+        }
+    }
+    
+    func getUserInfo() {
+        Task {
+            let phone_uid = await UIDevice.current.identifierForVendor!.uuidString
+            let userInfo: UserInfoModel = try await ServerNetwork.shared.request(.getUserInfo(userID: phone_uid))
+            UserDefaultManager.setUserInfo(userInfo: userInfo)
         }
     }
 }


### PR DESCRIPTION
### 🔥 Issue Number
- #83 

### 📝 PR 내용 요약
- UserDefaultManager를 생성해요
- UserInfoViewModel의 데이터를 옮겨요
- get, set 로직을 수정해요

### 🧐 추가 설명
- 기존에 서버에서 저장하던 정보들을 비휘발 메모리인 UserDefault로 옮기는 작업이에요
- 더이상 서버에서 유저마다의 설정을 저장할 필요가 없어져요
