### PR TITLE
GoalCount range를 수정했어요

### DIFF
--- a/Daily/Presentation/Goal/GoalView.swift
+++ b/Daily/Presentation/Goal/GoalView.swift
@@ -438,7 +438,7 @@ struct GoalCountSection: View {
                                 goalViewModel.hidePopover()
                             } else {
                                 goalViewModel.showPopover(at: position) {
-                                    DailyPicker(range: 0 ... goalViewModel.goal.count, selection: $goalViewModel.record.count, maxWidth: width)
+                                    DailyPicker(range: 0 ... 10, selection: $goalViewModel.record.count, maxWidth: width)
                                 }
                             }
                         } label: {
@@ -525,7 +525,7 @@ struct GoalCountSection: View {
                             goalViewModel.hidePopover()
                         } else {
                             goalViewModel.showPopover(at: position) {
-                                DailyPicker(range: max(1, goalViewModel.record.count) ... 10, selection: $goalViewModel.goal.count, maxWidth: width)
+                                DailyPicker(range: 1 ... 10, selection: $goalViewModel.goal.count, maxWidth: width)
                             }
                         }
                     } label: {


### PR DESCRIPTION
### 🔥 Issue Number
- #161 

### 📝 PR 내용 요약
- 타이머와의 통일성을 맞추기 위해서 기록 카운트는 0~10, 목표 카우트는 1~10으로 수정했어요

### 🧐 추가 설명
- 애니메이션과 관련된 UI/UX 개선은 2.1.0 업데이트 이후 이어질 예정이에요
