### PR TITLE
투두를 생성했을 때 토스트 메시지를 추가했어요

### DIFF
--- a/Daily/Domain/Entities/Enums/DailyAlert.swift
+++ b/Daily/Domain/Entities/Enums/DailyAlert.swift
@@ -141,3 +141,20 @@ enum NoticeAlert: DailyAlert {
         }
     }
 }
+
+// MARK - SuccessAlert
+enum SuccessAlert: DailyAlert {
+    case addGoal
+    
+    var icon: ImageResource? { return .complete }
+    
+    var titleText: String { return "" }
+    
+    var messageText: String {
+        switch self {
+        case .addGoal:
+            return "목표가 추가되었어요" // FIXME: 추후 영어 문구 받아서 Localization 적용
+        }
+    }
+    
+}

--- a/Daily/Domain/Entities/Enums/DailyAlert.swift
+++ b/Daily/Domain/Entities/Enums/DailyAlert.swift
@@ -153,7 +153,7 @@ enum SuccessAlert: DailyAlert {
     var messageText: String {
         switch self {
         case .addGoal:
-            return "목표가 추가되었어요" // FIXME: 추후 영어 문구 받아서 Localization 적용
+            return "goal_added".localized
         }
     }
     

--- a/Daily/Presentation/Goal/GoalView.swift
+++ b/Daily/Presentation/Goal/GoalView.swift
@@ -42,8 +42,9 @@ struct GoalView: View {
         }
     }
     
-    private func successAction(newDate: Date?) {
+    private func successAction(isAddGoal: Bool, newDate: Date?) {
         dismiss()
+        if isAddGoal { alertEnvironment.showToast(alertType: SuccessAlert.addGoal) }
         if let newDate { calendarViewModel.setDate(date: newDate) }
     }
     

--- a/Daily/Presentation/Goal/GoalViewModel.swift
+++ b/Daily/Presentation/Goal/GoalViewModel.swift
@@ -105,7 +105,7 @@ extension GoalViewModel {
 
 // MARK: - button func
 extension GoalViewModel {
-    func add(successAction: @escaping (Date?) -> Void, validateAction: @escaping (DailyAlert) -> Void) {
+    func add(successAction: @escaping (Bool, Date?) -> Void, validateAction: @escaping (DailyAlert) -> Void) {
         if let validate = validate() { validateAction(validate); return }
         Task { @MainActor in
             let goal = DailyGoalModel(from: goal)
@@ -115,11 +115,11 @@ extension GoalViewModel {
             goal.records = records
             await goalUseCase.addGoal(goal: goal)
             
-            successAction(startDate)
+            successAction(true, startDate)
         }
     }
     
-    func modify(successAction: @escaping (Date?) -> Void, validateAction: @escaping (DailyAlert) -> Void) {
+    func modify(successAction: @escaping (Bool, Date?) -> Void, validateAction: @escaping (DailyAlert) -> Void) {
         guard let modifyType else { return }
         if let validate = validate() { validateAction(validate); return }
         
@@ -193,7 +193,7 @@ extension GoalViewModel {
                 
                 await goalUseCase.updateData()
             }
-            successAction(record.date)
+            successAction(false, record.date)
         }
     }
     

--- a/Daily/Resource/en.lproj/Localizable.strings
+++ b/Daily/Resource/en.lproj/Localizable.strings
@@ -113,6 +113,7 @@
 "you_will_be_notified_before" = "You`ll be notified %@ before";
 "noticifation_removed" = "Notification removed";
 "notification_deleted_with_the_goal" = "Notification deleted with the goal";
+"goal_added" = "Goal added";
 
 // MARK: - Menu
 "turn_on_notification" = "Turn On Notification";

--- a/Daily/Resource/ko.lproj/Localizable.strings
+++ b/Daily/Resource/ko.lproj/Localizable.strings
@@ -113,6 +113,7 @@
 "you_will_be_notified_before" = "설정한 시간 %@ 전에 알려드릴게요";
 "noticifation_removed" = "알림이 삭제되었어요";
 "notification_deleted_with_the_goal" = "알림이 함께 삭제되었어요";
+"goal_added" = "목표가 추가되었어요";
 
 // MARK: - Menu
 "turn_on_notification" = "알림 켜기";


### PR DESCRIPTION
### 🔥 Issue Number
- #184 

### 📝 PR 내용 요약
- SuccessAlert를 추가해 연 달력 또는 월 달력에서도 투두가 추가되었을 때 시각적으로 인지할 수 있도록 토스트 메시지를 추가했어요

### 🧐 추가 설명
- 회의 결과 조금 라이트한 방식으로 알려주기로 결정됐어요 (어떤 날짜에 추가됐는지 어디있는지 등 자세한 내용은 모를 수도 있어요)
