### PR TITLE
record보다 goal이 먼저 삭제되는 버그를 수정했어요

### DIFF
--- a/Daily/Domain/Entities/Model/DailyRecordModel.swift
+++ b/Daily/Domain/Entities/Model/DailyRecordModel.swift
@@ -43,7 +43,7 @@ class DailyRecordModel: Navigatable {
     }
 }
 extension DailyRecordModel {
-    func copy(goal: DailyGoalModel) -> DailyRecordModel {
+    func copy(goal: DailyGoalModel?) -> DailyRecordModel {
         return DailyRecordModel(
             goal: goal,
             date: self.date,

--- a/Daily/Presentation/Calendar/CalendarViewModel.swift
+++ b/Daily/Presentation/Calendar/CalendarViewModel.swift
@@ -261,6 +261,7 @@ extension CalendarViewModel {
     private func deleteRecords(records: [DailyRecordModel]) async {
         for record in records {
             if let noticeDate = CalendarServices.shared.getValidNoticeDate(record: record), noticeDate > Date() {
+                // FIXME: 다중 목표 삭제 시 푸시 알림이 제대로 삭제되지 않는 버그 확인 필요
                 PushNoticeManager.shared.removeNotice(id: String(describing: record.id))
             }
             await calendarUseCase.deleteRecord(record: record)

--- a/Daily/Presentation/Calendar/CalendarViewModel.swift
+++ b/Daily/Presentation/Calendar/CalendarViewModel.swift
@@ -238,8 +238,8 @@ extension CalendarViewModel {
         guard let records = goal.records else { return }
         Task {
             await resetData()
-            await calendarUseCase.deleteGoal(goal: goal)
             await deleteRecords(records: records)
+            await calendarUseCase.deleteGoal(goal: goal)
             
             fetchDayData(selection: currentDate.getSelection(type: .day))
             fetchWeekData(selection: currentDate.getSelection(type: .week))
@@ -261,7 +261,6 @@ extension CalendarViewModel {
     private func deleteRecords(records: [DailyRecordModel]) async {
         for record in records {
             if let noticeDate = CalendarServices.shared.getValidNoticeDate(record: record), noticeDate > Date() {
-                // FIXME: 다중 목표 삭제 시 푸시 알림이 제대로 삭제되지 않는 버그 확인 필요
                 PushNoticeManager.shared.removeNotice(id: String(describing: record.id))
             }
             await calendarUseCase.deleteRecord(record: record)


### PR DESCRIPTION
### 🔥 Issue Number
- #213 

### 📝 PR 내용 요약
- deleteGoal 내부 로직 순서 변경

### 🧐 추가 설명
- goal이 먼저 삭제되어 validate notice가 검색되지 않는 버그였어요, record를 먼저 삭제하도록 순서를 변경해 알림이 먼저 정상적으로 삭제되도록 수정했어요
